### PR TITLE
Reworked stakes and added logs to vote

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       postgres_db: graph-node
       ipfs: 'ipfs:5001'
       # Change next line if you want to connect to a different JSON-RPC endpoint
-      ethereum: 'private:http://host.docker.internal:8545'
+      ethereum: 'private:http://172.20.0.1:8545'
       GRAPH_LOG: info
       GRAPH_ALLOW_NON_DETERMINISTIC_IPFS: 'true'
   ipfs:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -18,7 +18,7 @@ services:
       postgres_db: graph-node
       ipfs: 'ipfs:5001'
       # Change next line if you want to connect to a different JSON-RPC endpoint
-      ethereum: 'private:http://172.20.0.1:8545'
+      ethereum: 'private:http://host.docker.internal:8545'
       GRAPH_LOG: info
       GRAPH_ALLOW_NON_DETERMINISTIC_IPFS: 'true'
   ipfs:
@@ -38,3 +38,4 @@ services:
       POSTGRES_DB: graph-node
     volumes:
       - ./data/postgres:/var/lib/postgresql/data
+

--- a/src/mappings/DXDVotingMachine/mapping.ts
+++ b/src/mappings/DXDVotingMachine/mapping.ts
@@ -1,5 +1,5 @@
 import { BigInt } from '@graphprotocol/graph-ts';
-import { Stake, Vote, DAO } from '../../types/schema';
+import { Stake, Vote, DAO, Redeem } from '../../types/schema';
 import {
   VoteProposal,
   Stake as StakeEvent,
@@ -28,8 +28,12 @@ export function handleVoteProposal(event: VoteProposal): void {
 }
 
 export function handleStake(event: StakeEvent): void {
-  const stakeId = `${event.params._proposalId.toHexString()}-${event.params._staker.toHexString()}`;
+  const stakeId = `${event.params._proposalId.toHexString()}-${event.params._staker.toHexString()}-${
+    event.block.timestamp
+  }-stake`;
 
+  // In the most common case, each staking is unique
+  // We load to handle the edge case of someone staking twice on the same block
   let stake = Stake.load(stakeId);
   if (!stake) {
     stake = new Stake(stakeId);
@@ -40,18 +44,32 @@ export function handleStake(event: StakeEvent): void {
   stake.avatar = event.params._avatar.toHexString();
   stake.staker = event.params._staker.toHexString();
   stake.vote = event.params._vote;
-  stake.amount = stake.amount.plus(event.params._amount);
+  stake.amount = event.params._amount;
+  stake.timestamp = event.block.timestamp;
+  stake.txId = event.transaction.hash.toHexString();
 
   stake.save();
 }
 
 export function handleRedeem(event: RedeemEvent): void {
-  const stakeId = `${
+  const redeemId = `${
     event.params._proposalId
-  }-${event.params._beneficiary.toHexString()}`;
-  const stake = Stake.load(stakeId);
-  if (!stake) return;
+  }-${event.params._beneficiary.toHexString()}-${event.block.timestamp}-redeem`;
 
-  stake.amount = stake.amount.minus(event.params._amount);
-  stake.save();
+  // In the most common case, each redeem is unique
+  // We load to handle the edge case of someone redeeming twice on the same block
+  let redeem = Redeem.load(redeemId);
+  if (!redeem) {
+    redeem = new Redeem(redeemId);
+  }
+
+  redeem.proposal = event.params._proposalId.toHexString();
+  redeem.avatar = event.params._avatar.toHexString();
+  redeem.redeemer = event.params._beneficiary.toHexString();
+  redeem.amount = event.params._amount;
+  redeem.timestamp = event.block.timestamp;
+  redeem.txId = event.transaction.hash.toHexString();
+
+  redeem.save();
 }
+

--- a/src/mappings/DXDVotingMachine/schema.graphql
+++ b/src/mappings/DXDVotingMachine/schema.graphql
@@ -1,9 +1,19 @@
 type Vote @entity {
   id: ID!
   proposal: Proposal!
+  voterAddress: String!
   member: Member
   vote: BigInt!
   reputation: BigInt!
+  voteLogs: [VoteLog!] @derivedFrom(field: "vote")
+}
+
+type VoteLog @entity {
+  id: ID!
+  reputation: BigInt!
+  timestamp: BigInt!
+  txId: String!
+  vote: Vote!
 }
 
 type Stake @entity {
@@ -13,6 +23,7 @@ type Stake @entity {
   staker: String!
   vote: BigInt!
   amount: BigInt!
+
   timestamp: BigInt!
   txId: String!
 }
@@ -23,6 +34,7 @@ type Redeem @entity {
   avatar: String!
   redeemer: String!
   amount: BigInt!
+
   timestamp: BigInt!
   txId: String!
 }

--- a/src/mappings/DXDVotingMachine/schema.graphql
+++ b/src/mappings/DXDVotingMachine/schema.graphql
@@ -13,5 +13,17 @@ type Stake @entity {
   staker: String!
   vote: BigInt!
   amount: BigInt!
+  timestamp: BigInt!
+  txId: String!
+}
+
+type Redeem @entity {
+  id: ID!
+  proposal: Proposal!
+  avatar: String!
+  redeemer: String!
+  amount: BigInt!
+  timestamp: BigInt!
+  txId: String!
 }
 


### PR DESCRIPTION
**Stake / Redeem**
Now stakes and redeems are unique entries: every stake/redeem will create a new entry, with a timestamp suffix.

**VoteLogs**
Every vote creates a new VoteLog entry. This entry will track the reputation, timestamp and transaction hash. This entity is related many-to-one with each vote, so we now can keep a log of voting power changes.