### PR TITLE
Added logs for proposal state

### DIFF
--- a/src/mappings/DXDVotingMachine/template.yaml
+++ b/src/mappings/DXDVotingMachine/template.yaml
@@ -11,4 +11,6 @@ eventHandlers:
     handler: handleStake
   - event: Redeem(indexed bytes32,indexed address,indexed address,uint256)
     handler: handleRedeem
+  - event: StateChange(indexed bytes32,uint8)
+    handler: handleStateChange
 

--- a/src/mappings/Scheme/schema.graphql
+++ b/src/mappings/Scheme/schema.graphql
@@ -32,6 +32,25 @@ type Proposal @entity {
   # Related entities
   votes: [Vote!] @derivedFrom(field: "proposal")
   stakes: [Stake!] @derivedFrom(field: "proposal")
+  stateLogs: [StateLog!] @derivedFrom(field: "proposal")
+  votingMachineProposalStateLogs: [VotingMachineProposalStateLog!]
+    @derivedFrom(field: "proposal")
+}
+
+type StateLog @entity {
+  id: ID!
+  timestamp: BigInt!
+  txId: String!
+  state: ProposalState!
+  proposal: Proposal!
+}
+
+type VotingMachineProposalStateLog @entity {
+  id: ID!
+  timestamp: BigInt!
+  txId: String!
+  state: VotingMachineProposalState!
+  proposal: Proposal!
 }
 
 enum ProposalState {


### PR DESCRIPTION
We now create logs for proposal state changes (both for the state in the Scheme and the Voting Machine).

The logs include:
1. Timestamp
2. Transaction hash
3. New state
4. Related proposal

We don't track the Execution State since there wasn't a reliable event we could hook to. We didn't deem it necessary for now, but if it is, we should add a new event.